### PR TITLE
fix: change node engine version to string type

### DIFF
--- a/packages/firebase/scripts/build.sh
+++ b/packages/firebase/scripts/build.sh
@@ -8,4 +8,4 @@ cp -r ../app/public ./public
 mkdir -p lib/config
 mv public/static/bundle/scripts.html lib/config/scripts.html
 
-jq < package.json '.engines.node = 10' > lib/package.json
+jq < package.json '.engines.node = "10"' > lib/package.json


### PR DESCRIPTION
I get the following error when trying to deploy using `.\scripts\deploy.sh production`:

```
i  deploying functions
i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
i  functions: ensuring required API cloudbuild.googleapis.com is enabled...
✔  functions: required API cloudbuild.googleapis.com is enabled
✔  functions: required API cloudfunctions.googleapis.com is enabled
i  functions: preparing lib directory for uploading...
i  functions: packaged lib (25.43 KB) for uploading
✔  functions: lib folder uploaded successfully
i  functions: updating Node.js 10 function app(us-central1)...
i  functions: updating Node.js 10 function slack(us-central1)...
i  functions: updating Node.js 10 function job(us-central1)...
⚠  functions[slack(us-central1)]: Deployment error.
Build failed: unmarshalling package.json: json: cannot unmarshal number into Go struct field packageEnginesJSON.engines.node of type string; Error ID: 5fcdd9ab
⚠  functions[job(us-central1)]: Deployment error.
Build failed: unmarshalling package.json: json: cannot unmarshal number into Go struct field packageEnginesJSON.engines.node of type string; Error ID: 5fcdd9ab
⚠  functions[app(us-central1)]: Deployment error.
Build failed: unmarshalling package.json: json: cannot unmarshal number into Go struct field packageEnginesJSON.engines.node of type string; Error ID: 5fcdd9ab

```

It seems to be an issue with the node engine version in the firebase `package.json`, it needs to be a string type. The `build.sh` script is writing is as an int. I've updated the script to write it as a string property. I was able to successfully deploy the functions after making change.

I've migrated to a self hosted version and got everything working, I have few other things to contribute, including some documentation improvements for firebase deployment. If you are looking for contributors/help, I'm happy to lend some time.