### PR TITLE
Feature: Self-Hosted Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:10.18.1-stretch-slim as builder
+COPY . /app
+WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y jq \
+    && apt-get clean
+RUN yarn policies set-version
+RUN yarn
+RUN yarn build
+
+FROM bitnami/node:10-prod
+ENV NODE_ENV="production"
+COPY --from=builder /app /app
+WORKDIR /app
+EXPOSE 3000
+CMD ["yarn", "server"]

--- a/deliverybot-deployment.yml
+++ b/deliverybot-deployment.yml
@@ -1,0 +1,61 @@
+apiVersion: v1
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deliverybot
+  spec:
+    selector:
+      matchLabels:
+        app: deliverybot
+    replicas: 1
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: deliverybot
+      spec:
+        containers:
+        - name: deliverybot
+          image: ramene/deliverybot:0.7.2
+          ports:
+          - containerPort: 3000
+            name: http
+          resources: {}
+        restartPolicy: Always
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: deliverybot-service
+  spec:
+    ports:
+    - name: http
+      port: 80
+      targetPort: http
+    selector:
+      app: deliverybot
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: deliverybot-data-pvc
+    annotations: {}
+    labels:
+      app: deliverybot
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Mi
+  status: {}
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: deliverybot-configmap
+    labels:
+      app: deliverybot
+  data:
+    .env: |-
+kind: List
+metadata: {}

--- a/ngrok-deployment.yml
+++ b/ngrok-deployment.yml
@@ -1,0 +1,40 @@
+apiVersion: v1
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: ngrok
+  spec:
+    selector:
+      matchLabels:
+        app: ngrok
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: ngrok
+      spec:
+        containers:
+        - name: ngrok
+          image: ramene/ngrok
+          command: ["ngrok"]
+          args: ["http", "-hostname=app.example.com", "deliverybot-service"]
+          ports:
+          - containerPort: 4040
+            name: http
+          resources: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ngrok-service
+  spec:
+    type: NodePort
+    ports:
+      - name: http
+        port: 4040
+        targetPort: 4040
+        protocol: TCP
+    selector:
+      app: ngrok
+kind: List
+metadata: {}

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -13,7 +13,7 @@ function proxy() {
   const SmeeClient = require("smee-client");
   const smee = new SmeeClient({
     source: process.env.WEBHOOK_PROXY_URL,
-    target: `http://localhost:3000`
+    target: `http://0.0.0.0:3000`
   });
   smee.start();
 }


### PR DESCRIPTION
This feature adds the ability to run deliverybot locally and exposed through ngrok via public internet. Runs on Kubernetes anywhere (Azure, minikube, AWS, GCP and more!).

The Dockerfile consists of a simple multistage build. The first stage uses the node official image, `node:10.18.1-stretch-slim`, to copy the application source and install the required application modules using **`yarn`**.   Optionally, the NODE_ENV environment variable is defined so that yarn install only installs the application modules that are required in production executions.

The second stage uses the production image, [bitnami/node:10-prod](https://github.com/bitnami/bitnami-docker-node), and copies over the application source and packages from the previous stage.  Currently, just copies everything over wholesale. This results in a minimal Docker image that only consists of deliverybot source, UI, node modules and the node runtime.

### Building and Deploying

To build the Docker image, execute the command:

`$ docker build .`

The `deliverybot-deployment.yml` file can be used, once the resulting container is pushed to Dockerhub, to deploy deliverybot to any Kubernetes cluster., additionally, per the official GitHub Application development documentation, the accompanying `ngrok-deployment.yml` can be used to deploy ngrok itself and expose the deployed service via your reserved domain.

This approach was born from [Stefan Prodan](https://github.com/stefanprodan) and his ngrok [container](https://github.com/stefanprodan/ngrok)

_Assuming familiarity with `ngrok` and configuring reserved domains; otherwise, you could simply use `kubectl port-forward` to expose deliverybot service locally all the same._

Simply deploy the appropriate manifest(s) against your cluster.

> `$ kubectl apply -f deliverybot-deployment.yml`

Optionally,
> `$ kubectl apply -f ngrok-deployment.yml`

### Accessing the application

Once, deployed –– you can either expose the service, via ingress, port-forwarding, or assuming you have an ngrok PRO account and the pods are running, the tunnel is effectively open.  Visit the domain as configured  _i.e._ http://app.example.com

_Requires updating `ngrok.yml` with your account authToken_

### Check Status via `ngrok` Dashboard

Expose dashboard

`kubectl port-forward $(kubectl get pods -l app=ngrok -o jsonpath="{ .items[0].metadata.name }") 4040:4040`

Alternatively, 
```sh
kubectl exec $(kubectl get pods -l=app=ngrok -o=jsonpath='{.items[0].metadata.name}') -- curl http://localhost:4040/api/tunnels
```

<img width="967" alt="Screen Shot 2020-08-30 at 12 01 20 AM" src="https://user-images.githubusercontent.com/20915047/91650993-dd597000-ea54-11ea-8a13-41aaab6b46c3.png">

### Testing 
Currently tested against minikube, EKS and k3s after having successfully installed deliverybot and triggering deployments via reserved domain.

<img width="807" alt="Screen Shot 2020-08-29 at 10 31 30 PM" src="https://user-images.githubusercontent.com/20915047/91650415-62408b80-ea4d-11ea-89b0-a49c86128c8a.png">

### Known Issues

––  All external links in the UI are currently still pointing at deliverybot.dev.  Future updates will incorporate a more configurable approach

–– If you're GitHub Application has not yet been made **Public**, I've noticed I have to **Install App** under [GitHub Application Settings](https://github.com/settings/apps/CHANGEME/installations) **_first_**, which will then redirect to my domain as configured.

