### PR TITLE
feat: adds github enterprise support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ APP_ID=
 WEBHOOK_SECRET=
 PRIVATE_KEY=
 
+# Set the GHE_HOST environment variable if you want to run against
+# a GitHub Enterprise instance. i.e. `GHE_HOST=github.hostname.com`.
+GHE_HOST=
+
 # Use `trace` to get verbose logging or `info` to show less.
 LOG_LEVEL=debug
 LOG_FORMAT=json

--- a/packages/core/src/probot.ts
+++ b/packages/core/src/probot.ts
@@ -13,6 +13,7 @@ export interface AppOptions {
   webhookPath: string;
   webhookSecret: string;
   logger: Logger;
+  baseUrl?: string;
 }
 
 const cache = createDefaultCache();
@@ -24,6 +25,7 @@ export function app(opts: AppOptions) {
     app: new OctokitApp({
       id: opts.id,
       privateKey: opts.privateKey,
+      baseUrl: opts.baseUrl ? `https://${opts.baseUrl}/api/v3` : undefined
     }),
     cache,
   });

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -12,6 +12,7 @@ const opts: Options = {
   webhookSecret: env("WEBHOOK_SECRET"),
   appSecret: env("WEBHOOK_SECRET") || "development",
   privateKey: env("PRIVATE_KEY"),
+  baseUrl: env("GHE_HOST"),
   config: {
     slackLoginUrl: env("SLACK_LOGIN_URL"),
     slackClientId: env("SLACK_CLIENT_ID"),


### PR DESCRIPTION
Adds support to run `deliverybot` on Github Enterprise 3.0+.