### PR TITLE
Basic guide to simple self-hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 ENVIRONMENT=development
 NODE_ENV=development
 
+# Hosted location
+BASE_URL=
+
 # GitHub App configuration.
 CLIENT_ID=
 CLIENT_SECRET=

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -1,13 +1,13 @@
 # Hosting
 
-As of September 20th 2020, DeliveryBot transitioned to be a [project that you will deploy yourself on your own infrastructure](https://deliverybot.dev/2020/02/14/deliverybot-goes-open-source/). This document explains a simple path to hosting DeliveryBot yourself.
+As of September 20th 2020, DeliveryBot transitioned to be a "[project that you will deploy yourself on your own infrastructure](https://deliverybot.dev/2020/02/14/deliverybot-goes-open-source/)". This document explains a simple path to hosting DeliveryBot yourself.
 
 ## Create a GitHub App
-The first step is to create a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps). The app mostly a set of permissions and integration points.
+The first step is to create a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps).
 
-1. Navigate through GitHub's UI or [New GitHub App](https://github.com/settings/apps/new)
+1. [New GitHub App](https://github.com/settings/apps/new)
 2. `GitHub App Name` - Name the app, maybe something like `DeliveryBot (Hosted by your.org)`
-3. `Homepage URL` - The URL where you expect to be hosting delivery bot (eg. `https://deliverybot.your.org`)
+3. `Homepage URL` - The URL where you expect to be hosting DeliveryBot (eg. `https://deliverybot.your.org`)
 4. `Callback URL` - An absolute URL with path `/login/cb` (eg. `https://deliverybot.your.org/login/cb`)
 5. `Expire user authorization tokens` - Check this
 6. **Permissions and Events** - [This Manifest](https://github.com/deliverybot/deliverybot/blob/master/app.yml) describes the exact permissions which should be granted. You can [use Probot](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app-from-a-manifest) to actually create the app from the manifest, but learning Probot takes more than the one minute it takes to set the permissions manually.
@@ -49,3 +49,5 @@ yarn install
 yarn build
 yarn start
 ```
+
+The service should be running on port 3000.

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -1,0 +1,51 @@
+# Hosting
+
+As of September 20th 2020, DeliveryBot transitioned to be a "project that you will deploy yourself on your own infrastructure". This document explains a simple path to hosting DeliveryBot on your own infrastructure.
+
+## Create a GitHub App
+The first step is to create a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps). The app mostly a set of permissions and integration points.
+
+1. Navigate through GitHub's UI or [New GitHub App](https://github.com/settings/apps/new)
+2. `GitHub App Name` - Name the app, maybe something like `DeliveryBot (Hosted by your.org)`
+3. `Homepage URL` - The URL where you expect to be hosting delivery bot (eg. `https://deliverybot.your.org`)
+4. `Callback URL` - An absolute URL with path `/login/cb` (eg. `https://deliverybot.your.org/login/cb`)
+5. `Expire user authorization tokens` - Check this
+6. **Permissions and Events** - [This Manifest](https://github.com/deliverybot/deliverybot/blob/master/app.yml) describes the exact permissions which should be granted. You can [use Probot](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app-from-a-manifest) to actually create the app from the manifest, but learning Probot takes more than the one minute it takes to set the permissions manually.
+7. `Where can this GitHub App be installed?` - Only on this account
+8. Create the app
+9. Generate client secrets
+
+## The Environment
+Starting from [.env.example](https://github.com/deliverybot/deliverybot/blob/master/.env.example).
+
+```
+# Environment configuration.
+ENVIRONMENT=production
+NODE_ENV=production
+
+# Hosted location
+BASE_URL=https://deliverybot.your.org
+
+# GitHub App configuration.
+APP_ID=GitHub should tell you the "App ID". It was a six-digit number for me.
+CLIENT_ID=When you create the client secret
+CLIENT_SECRET=When you create the client secret
+WEBHOOK_SECRET= # Blank
+PRIVATE_KEY= # Blank
+
+# Use `trace` to get verbose logging or `info` to show less.
+LOG_LEVEL=debug
+LOG_FORMAT=json
+
+# Go to https://smee.io/new set this to the URL that you are redirected to.
+WEBHOOK_PROXY_URL=<blank>
+```
+
+### Run Services
+With the above environment variables
+
+```
+yarn install
+yarn build
+yarn start
+```

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -1,6 +1,6 @@
 # Hosting
 
-As of September 20th 2020, DeliveryBot transitioned to be a "project that you will deploy yourself on your own infrastructure". This document explains a simple path to hosting DeliveryBot on your own infrastructure.
+As of September 20th 2020, DeliveryBot transitioned to be a [project that you will deploy yourself on your own infrastructure](https://deliverybot.dev/2020/02/14/deliverybot-goes-open-source/). This document explains a simple path to hosting DeliveryBot yourself.
 
 ## Create a GitHub App
 The first step is to create a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps). The app mostly a set of permissions and integration points.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For more, check out the [Contributing Guide](CONTRIBUTING.md).
 ### Setup
 
     yarn install
+    yarn build
     yarn start
 
 ## License


### PR DESCRIPTION
This is a very simple guide to self-hosting the DeliveryBot services. I tried to avoid the complexity of any specific hosting decisions - Docker, Kubernetes, etc. And avoid the complexity of any _optional_ integrations like Slack etc.  This seemed to be, the minimum information needed to get started self-hosting DeliveryBot.

In my experiences, the most confusing parts of the current experience was:

1. `yarn build` is missing from setup scripts
2. `BASE_URL` is needed but undocumented and missing from the `.env.example`
3. The basics of creating the GitHub App aren't documented. I had to string together information from several different places (github issues, community threads, manifest, probot, cb url, etc.)

cc @nomulex